### PR TITLE
Feature/refactoring align entities with db schema -> devlop

### DIFF
--- a/src/entities/business-contact.entity.ts
+++ b/src/entities/business-contact.entity.ts
@@ -6,17 +6,22 @@ export class BusinessContact {
   @PrimaryGeneratedColumn()
   contact_id: number;
 
-  @ManyToOne(() => UserAccount, userAccount => userAccount.contacts)
+  @ManyToOne(() => UserAccount, userAccount => userAccount.contacts, { nullable: false })
   @JoinColumn({ name: 'user_id' })
   userAccount: UserAccount;
 
-  @ManyToOne(() => UserAccount, contact_user => contact_user.contactOf)
+  @ManyToOne(() => UserAccount, contact_user => contact_user.contactOf, { nullable: false })
   @JoinColumn({ name: 'contact_user_id' })
   contact_user: UserAccount;
 
-  @CreateDateColumn()
+  @CreateDateColumn({
+    type: 'timestamp',
+})
   created_at: Date;
 
-  @DeleteDateColumn()
+  @DeleteDateColumn({
+    type: 'timestamp',
+    nullable: true 
+})
   deleted_at: Date;
 }

--- a/src/entities/business-profile.entity.ts
+++ b/src/entities/business-profile.entity.ts
@@ -11,21 +11,44 @@ export class BusinessProfile {
   @JoinColumn({ name: 'user_id' })
   userAccount: UserAccount;
 
-  @Column()
+  @Column({
+    type: 'varchar', 
+    length: 100, 
+    nullable: false 
+})
   company: string;
 
-  @Column()
+  @Column({
+    type: 'varchar', 
+    length: 100, 
+    nullable: false 
+})
   department: string;
 
-  @Column()
+  @Column({
+    type: 'varchar', 
+    length: 100, 
+    nullable: false 
+})
   position: string;
 
-  @Column()
+  @Column({
+    type: 'varchar', 
+    length: 100, 
+    nullable: false 
+})
   email: string;
 
-  @Column()
+  @Column({
+    type: 'varchar', 
+    length: 20, 
+    nullable: false 
+})
   phone: string;
 
-  @DeleteDateColumn()
+  @DeleteDateColumn({
+    type: 'timestamp',
+    nullable: true 
+})
   deletedAt: Date;
 }

--- a/src/entities/business-profile.entity.ts
+++ b/src/entities/business-profile.entity.ts
@@ -47,6 +47,7 @@ export class BusinessProfile {
   phone: string;
 
   @DeleteDateColumn({
+    name: 'deleted_at',
     type: 'timestamp',
     nullable: true 
 })

--- a/src/entities/comment-like.entity.ts
+++ b/src/entities/comment-like.entity.ts
@@ -3,19 +3,20 @@ import { UserAccount } from './user-account.entity';
 import { Comment } from './comment.entity';
 
 @Entity()
-@Unique(['comment', 'user'])
 export class CommentLike {
   @PrimaryGeneratedColumn()
   comment_like_id: number;
 
-  @ManyToOne(() => Comment, comment => comment.commentLike) // 댓글과의 다대일 관계
+  @ManyToOne(() => Comment, comment => comment.commentLike, { nullable: false }) // 댓글과의 다대일 관계
   @JoinColumn({ name: 'comment_id' })
   comment: Comment;
 
-  @ManyToOne(() => UserAccount) // 좋아요를 누른 사용자와의 다대일 관계
+  @ManyToOne(() => UserAccount, { nullable: false } ) // 좋아요를 누른 사용자와의 다대일 관계
   @JoinColumn({ name: 'user_id' })
   user: UserAccount;
 
-  @CreateDateColumn()
+  @CreateDateColumn({
+    type: 'timestamp',
+})
   created_at: Date;
 }

--- a/src/entities/comment.entity.ts
+++ b/src/entities/comment.entity.ts
@@ -3,34 +3,44 @@ import { UserAccount } from './user-account.entity';
 import { Post } from './post.entity';
 import { CommentLike } from './comment-like.entity';
 
-@Index(['post', 'created_at'])
 @Entity()
 export class Comment {
   @PrimaryGeneratedColumn()
   comment_id: number;
 
-  @ManyToOne(() => Post, post => post.comments)
+  @ManyToOne(() => Post, post => post.comments, { nullable: false })
   @JoinColumn({ name: 'post_id' })
-  @Index()
   post: Post;
 
-  @ManyToOne(() => UserAccount, userAccount => userAccount.comments) // 댓글 작성자와의 다대일 관계
+  @ManyToOne(() => UserAccount, userAccount => userAccount.comments, { nullable: false }) // 댓글 작성자와의 다대일 관계
   @JoinColumn({ name: 'user_id' })
-  @Index()
   userAccount: UserAccount;
 
-  @Column('text')
+  @Column({
+    type: 'text', 
+    nullable: false 
+})
   content: string;
 
-  @CreateDateColumn()
+  @CreateDateColumn({
+    type: 'timestamp',
+    precision: 6
+})
   created_at: Date;
 
-  @Column({ default: 0 }) // 좋아요 수, 기본값은 0
+  @Column({
+    type: 'int', 
+    default: 0, 
+    nullable: true 
+}) // 좋아요 수, 기본값은 0
   like_count: number;
 
   @OneToMany(() => CommentLike, commentLike => commentLike.comment) // 댓글에 달린 좋아요와의 1:N 관계
   commentLike: CommentLike[];
 
-  @DeleteDateColumn()
+  @DeleteDateColumn({
+    type: 'timestamp',
+    nullable: true 
+})
   deleted_at: Date;
 }

--- a/src/entities/friend-request.entity.ts
+++ b/src/entities/friend-request.entity.ts
@@ -8,11 +8,11 @@ export class FriendRequest {
   @PrimaryGeneratedColumn()
   request_id: number;
 
-  @ManyToOne(() => UserAccount, user => user.sentFriendRequests)
+  @ManyToOne(() => UserAccount, user => user.sentFriendRequests, { nullable: false })
   @JoinColumn({ name: 'sender_id' }) // 친구 요청을 보낸 사용자, user_account 테이블과 외래 키 관계
   sender: UserAccount;
 
-  @ManyToOne(() => UserAccount, user => user.receivedFriendRequests)
+  @ManyToOne(() => UserAccount, user => user.receivedFriendRequests, { nullable: false })
   @JoinColumn({ name: 'receiver_id' }) // 친구 요청을 받은 사용자, user_account 테이블과 외래 키 관계
   receiver: UserAccount;
 
@@ -24,6 +24,8 @@ export class FriendRequest {
   status: 'pending' | 'accepted' | 'rejected'; // 요청 상태 (대기 중, 수락됨, 거절됨)
 
 
-  @CreateDateColumn()
+  @CreateDateColumn({
+    type: 'timestamp',
+})
   created_at: Date; // 요청이 생성된 날짜와 시간을 자동으로 기록
 }

--- a/src/entities/notification.entity.ts
+++ b/src/entities/notification.entity.ts
@@ -12,7 +12,8 @@ export class Notification {
   @JoinColumn({ name: 'user_id' })
   user: UserAccount;
 
-  @Column({ 
+  @Column({
+    name: 'sender_id',
     nullable: false
   })
   senderId: number;
@@ -32,17 +33,20 @@ export class Notification {
   message: string;
 
   @Column({
+    name: `is_read`,
     default: false,
     nullable: false
 })
 isRead: boolean; // 알림 읽음 여부
 
   @CreateDateColumn({
+    name: `created_at`,
     type: 'timestamp'
 })
 createdAt: Date; // 알림 생성 시간
 
 @DeleteDateColumn({
+  name: 'deleted_at',
   type: 'timestamp',
   nullable: true
 })

--- a/src/entities/notification.entity.ts
+++ b/src/entities/notification.entity.ts
@@ -4,33 +4,49 @@ import { Post } from './post.entity';
 import { Comment } from './comment.entity';
 
 @Entity()
-@Index(['user', 'createdAt'])
 export class Notification {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => UserAccount, user => user.notifications)
+  @ManyToOne(() => UserAccount, user => user.notifications, { nullable: false })
   @JoinColumn({ name: 'user_id' })
   user: UserAccount;
 
-  @Column({ name: 'sender_id', nullable: false })
+  @Column({ 
+    nullable: false
+  })
   senderId: number;
 
-  @Column()
+  @Column({
+    type: 'varchar', 
+    length: 50, 
+    nullable: false 
+})
   type: string;
 
-  @Column()
+  @Column({
+    type: 'varchar', 
+    length: 255, 
+    nullable: false 
+})
   message: string;
 
-  @Column({ name: 'is_read', default: false })
-  isRead: boolean; // 알림 읽음 여부
+  @Column({
+    default: false,
+    nullable: false
+})
+isRead: boolean; // 알림 읽음 여부
 
-  @Index()
-  @CreateDateColumn({ name: 'created_at' })
-  createdAt: Date; // 알림 생성 시간
+  @CreateDateColumn({
+    type: 'timestamp'
+})
+createdAt: Date; // 알림 생성 시간
 
-  @DeleteDateColumn({ name: 'deleted_at' })
-  deletedAt: Date; // 소프트 삭제를 위한 삭제 시간 (null이면 삭제되지 않은 상태)
+@DeleteDateColumn({
+  type: 'timestamp',
+  nullable: true
+})
+deletedAt: Date; // 소프트 삭제를 위한 삭제 시간 (null이면 삭제되지 않은 상태)
 
   @ManyToOne(() => Post, { nullable: true })
   @JoinColumn({ name: 'postId' })

--- a/src/entities/post-like.entity.ts
+++ b/src/entities/post-like.entity.ts
@@ -3,19 +3,20 @@ import { UserAccount } from './user-account.entity';
 import { Post } from './post.entity';
 
 @Entity()
-@Unique(['post', 'userAccount'])
 export class PostLike {
   @PrimaryGeneratedColumn()
   post_like_id: number;
 
-  @ManyToOne(() => Post, post => post.postLikes)
+  @ManyToOne(() => Post, post => post.postLikes, { nullable: false })
   @JoinColumn({ name: 'post_id' })
   post: Post;
 
-  @ManyToOne(() => UserAccount, userAccount => userAccount.postLikes)
+  @ManyToOne(() => UserAccount, userAccount => userAccount.postLikes, { nullable: false } )
   @JoinColumn({ name: 'user_id' }) // 외래 키 user_id로 연결
   userAccount: UserAccount;
 
-  @CreateDateColumn()
+  @CreateDateColumn({ 
+    type: 'timestamp'
+})
   created_at: Date;
 }

--- a/src/entities/post.entity.ts
+++ b/src/entities/post.entity.ts
@@ -1,42 +1,59 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, JoinColumn, CreateDateColumn, DeleteDateColumn, Index   } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, JoinColumn, CreateDateColumn, DeleteDateColumn} from 'typeorm';
 import { UserAccount } from './user-account.entity';
 import { Comment } from './comment.entity';
 import { PostLike } from './post-like.entity';
 
 // Post 엔티티는 사용자가 작성한 게시물을 나타냅니다.
 @Entity()
-@Index(["user", "created_at"])
 export class Post {
   // post_id는 기본 키로 자동 생성.
   @PrimaryGeneratedColumn()
   post_id: number;
 
-  @ManyToOne(() => UserAccount, user => user.posts) // 작성자와의 다대일 관계
+  @ManyToOne(() => UserAccount, user => user.posts, { nullable: false } ) // 작성자와의 다대일 관계
   @JoinColumn({ name: 'user_id' }) // 외래 키 컬럼을 user_id로 지정
-  @Index()
   user: UserAccount;
 
-  @Column()
+  @Column({ 
+    type: 'varchar', 
+    length: 255, 
+    nullable: false 
+})
   image_url: string;
 
   // 게시물의 본문 내용을 텍스트로 저장
-  @Column('text')
+  @Column({ 
+    type: 'text', 
+    nullable: false 
+})
   content: string;
 
   // 게시물이 생성된 날짜 및 시간을 자동으로 저장
-  @CreateDateColumn()
-  @Index()
+  @CreateDateColumn({ 
+    type: 'timestamp'
+})
   created_at: Date;
 
-  @DeleteDateColumn() 
+  @DeleteDateColumn({ 
+    type: 'timestamp',
+    nullable: true 
+})
   deleted_at?: Date;
 
    // 게시물이 받은 좋아요 수를 저장
-  @Column({ default: 0 })
+   @Column({ 
+    type: 'int', 
+    default: 0, 
+    nullable: true 
+})
   post_like_count: number;
 
   // 게시물에 달린 댓글 수를 저장
-  @Column({ default: 0 })
+  @Column({ 
+    type: 'int', 
+    default: 0, 
+    nullable: true 
+})
   comments_count: number;
 
   // 게시물에 달린 여러 댓글과의 1:N 관계

--- a/src/entities/user-account.entity.ts
+++ b/src/entities/user-account.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToOne, OneToMany, DeleteDateColumn, Index  } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, OneToOne, OneToMany, DeleteDateColumn} from 'typeorm';
 import { BusinessProfile } from './business-profile.entity';
 import { BusinessContact } from './business-contact.entity';
 import { Post } from './post.entity';
@@ -9,31 +9,44 @@ import { Notification } from './notification.entity';
 
 // UserAccount 엔티티는 사용자의 계정 정보
 @Entity()
-@Index("idx_login_id", ["login_id"])
 export class UserAccount {
   // user_id는 기본 키로 자동 생성
   @PrimaryGeneratedColumn()
   user_id: number;
 
-  @Column({ unique: true }) // 로그인 ID, 중복 불가
-  @Index()
+  @Column({ 
+    type: 'varchar', 
+    length: 50, 
+    nullable: false 
+}) // 로그인 ID, 중복 불가
   login_id: string;
 
   // 사용자의 비밀번호를 저장
-  @Column()
+  @Column({ 
+    type: 'varchar', 
+    length: 255, 
+    nullable: false 
+})
   password: string;
 
   @Column()
   confirm_password: string;
 
-  @Column()
+  @Column({ 
+    type: 'varchar', 
+    length: 100, 
+    nullable: false 
+})
   name: string;
 
   // 계정이 삭제된 날짜를 기록합니다. 소프트 삭제를 위해 사용
-  @DeleteDateColumn()
+  @DeleteDateColumn({ 
+    type: 'timestamp',
+    nullable: true 
+})
   deletedAt: Date;
 
-  @OneToOne(() => BusinessProfile, businessContact => businessContact.userAccount) // 비즈니스 프로필과의 1:1 관계
+  @OneToOne(() => BusinessProfile, businessContact => businessContact.userAccount, { nullable: false } ) // 비즈니스 프로필과의 1:1 관계
   profile: BusinessProfile;
 
   @OneToMany(() => BusinessContact, businessContact => businessContact.userAccount) // 이 사용자가 소유한 연락처들과의 1:N 관계

--- a/src/migrations/1730901315571-RemoveCascade.ts
+++ b/src/migrations/1730901315571-RemoveCascade.ts
@@ -1,0 +1,115 @@
+import { MigrationInterface, QueryRunner, TableForeignKey } from "typeorm";
+
+export class RemoveCascade1730901315571 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+
+        // 1. friend_request 테이블의 기존 외래 키 (sender_id, receiver_id) 삭제
+        const friendRequestTable = await queryRunner.getTable("friend_request");
+        if (friendRequestTable) {
+            const fkSender = friendRequestTable.foreignKeys.find(fk => fk.columnNames.includes("sender_id"));
+            if (fkSender) {
+                await queryRunner.dropForeignKey("friend_request", fkSender);
+            }
+
+            const fkReceiver = friendRequestTable.foreignKeys.find(fk => fk.columnNames.includes("receiver_id"));
+            if (fkReceiver) {
+                await queryRunner.dropForeignKey("friend_request", fkReceiver);
+            }
+        }
+
+        // 2. notification 테이블의 모든 외래 키 삭제
+        const notificationTable = await queryRunner.getTable("notification");
+        if (notificationTable) {
+            const foreignKeys = notificationTable.foreignKeys;
+            for (const foreignKey of foreignKeys) {
+                await queryRunner.dropForeignKey("notification", foreignKey);
+            }
+        }
+
+        // 3. friend_request와 notification 테이블에 CASCADE 없이 새로운 외래 키 추가
+        await queryRunner.createForeignKey("friend_request", new TableForeignKey({
+            name: "FK_friend_request_sender",
+            columnNames: ["sender_id"],
+            referencedColumnNames: ["user_id"],
+            referencedTableName: "user_account"
+        }));
+
+        await queryRunner.createForeignKey("friend_request", new TableForeignKey({
+            name: "FK_friend_request_receiver",
+            columnNames: ["receiver_id"],
+            referencedColumnNames: ["user_id"],
+            referencedTableName: "user_account"
+        }));
+
+        await queryRunner.createForeignKey("notification", new TableForeignKey({
+            name: "FK_notification_user",
+            columnNames: ["user_id"],
+            referencedColumnNames: ["user_id"],
+            referencedTableName: "user_account"
+        }));
+
+        await queryRunner.createForeignKey("notification", new TableForeignKey({
+            name: "FK_notification_post",
+            columnNames: ["postId"],
+            referencedColumnNames: ["post_id"],
+            referencedTableName: "post"
+        }));
+
+        await queryRunner.createForeignKey("notification", new TableForeignKey({
+            name: "FK_notification_comment",
+            columnNames: ["commentId"],
+            referencedColumnNames: ["comment_id"],
+            referencedTableName: "comment"
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // 1. CASCADE 없는 외래 키 삭제
+        await queryRunner.dropForeignKey("friend_request", "FK_friend_request_sender");
+        await queryRunner.dropForeignKey("friend_request", "FK_friend_request_receiver");
+        await queryRunner.dropForeignKey("notification", "FK_notification_user");
+        await queryRunner.dropForeignKey("notification", "FK_notification_post");
+        await queryRunner.dropForeignKey("notification", "FK_notification_comment");
+
+        // 2. CASCADE 포함된 원래 외래 키 복구
+        await queryRunner.createForeignKey("friend_request", new TableForeignKey({
+            name: "FK_friend_request_sender",
+            columnNames: ["sender_id"],
+            referencedColumnNames: ["user_id"],
+            referencedTableName: "user_account",
+            onDelete: "CASCADE"
+        }));
+
+        await queryRunner.createForeignKey("friend_request", new TableForeignKey({
+            name: "FK_friend_request_receiver",
+            columnNames: ["receiver_id"],
+            referencedColumnNames: ["user_id"],
+            referencedTableName: "user_account",
+            onDelete: "CASCADE"
+        }));
+
+        await queryRunner.createForeignKey("notification", new TableForeignKey({
+            name: "FK_notification_user",
+            columnNames: ["user_id"],
+            referencedColumnNames: ["user_id"],
+            referencedTableName: "user_account",
+            onDelete: "CASCADE"
+        }));
+
+        await queryRunner.createForeignKey("notification", new TableForeignKey({
+            name: "FK_notification_post",
+            columnNames: ["postId"],
+            referencedColumnNames: ["post_id"],
+            referencedTableName: "post",
+            onDelete: "CASCADE"
+        }));
+
+        await queryRunner.createForeignKey("notification", new TableForeignKey({
+            name: "FK_notification_comment",
+            columnNames: ["commentId"],
+            referencedColumnNames: ["comment_id"],
+            referencedTableName: "comment",
+            onDelete: "CASCADE"
+        }));
+    }
+}

--- a/src/migrations/1730901902061-AddLikeUniqueConstraints.ts
+++ b/src/migrations/1730901902061-AddLikeUniqueConstraints.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner, TableIndex, Table } from "typeorm";
+
+export class AddLikeUniqueConstraints1730901902061 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+
+        // 1. post_like 테이블의 post_id, user_id에 대한 유니크 인덱스 추가
+        const postLikeTable = await queryRunner.getTable("post_like");
+        const existingPostLikeIndex = postLikeTable?.indices.find(
+            index => index.name === "IDX_155b6bea641466e2d27ade96a4"
+        );
+
+        // 인덱스가 이미 존재하지 않는 경우에만 생성
+        if (!existingPostLikeIndex) {
+            await queryRunner.createIndex('post_like', new TableIndex({
+                name: "IDX_155b6bea641466e2d27ade96a4",
+                columnNames: ['post_id', 'user_id'],
+                isUnique: true
+            }));
+        }
+
+        // 2. comment_like 테이블의 comment_id, user_id에 대한 유니크 인덱스 추가
+        const commentLikeTable = await queryRunner.getTable("comment_like");
+        const existingCommentLikeIndex = commentLikeTable?.indices.find(
+            index => index.name === "IDX_b81e662a725f9440050ac6e4e2"
+        );
+
+        // 인덱스가 이미 존재하지 않는 경우에만 생성
+        if (!existingCommentLikeIndex) {
+            await queryRunner.createIndex('comment_like', new TableIndex({
+                name: "IDX_b81e662a725f9440050ac6e4e2",
+                columnNames: ['comment_id', 'user_id'],
+                isUnique: true
+            }));
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+
+        // 1. post_like 테이블의 유니크 인덱스 삭제
+        const postLikeTable = await queryRunner.getTable("post_like");
+        const commentLikeTable = await queryRunner.getTable("comment_like");
+
+        // 2. comment_like 테이블의 유니크 인덱스 삭제
+        if (postLikeTable?.indices.find(index => index.name === "IDX_155b6bea641466e2d27ade96a4")) {
+            await queryRunner.dropIndex('post_like', "IDX_155b6bea641466e2d27ade96a4");
+        }
+
+        if (commentLikeTable?.indices.find(index => index.name === "IDX_b81e662a725f9440050ac6e4e2")) {
+            await queryRunner.dropIndex('comment_like', "IDX_b81e662a725f9440050ac6e4e2");
+        }
+    }
+}

--- a/src/migrations/1730903113777-AddLoginIdIndex.ts
+++ b/src/migrations/1730903113777-AddLoginIdIndex.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner, TableIndex, Table } from "typeorm";
+
+export class AddLoginIdIndex1730903113777 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const userTable = await queryRunner.getTable("user_account");
+        
+        // 1. user_account 테이블의 login_id 유니크 인덱스 추가
+        const existingUniqueIndex = userTable?.indices.find(
+            index => index.name === "IDX_3be8d6d99d1cfeb79ef24b7710"
+        );
+
+        // 유니크 인덱스가 이미 존재하지 않는 경우에만 생성
+        if (!existingUniqueIndex) {
+            await queryRunner.createIndex('user_account', new TableIndex({
+                name: "IDX_3be8d6d99d1cfeb79ef24b7710",
+                columnNames: ['login_id'],
+                isUnique: true
+            }));
+        }
+
+        // 2. user_account 테이블의 login_id 일반 인덱스 추가
+        const existingNormalIndex = userTable?.indices.find(
+            index => index.name === "idx_login_id"
+        );
+
+        // 일반 인덱스가 이미 존재하지 않는 경우에만 생성
+        if (!existingNormalIndex) {
+            await queryRunner.createIndex('user_account', new TableIndex({
+                name: "idx_login_id",
+                columnNames: ['login_id']
+            }));
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const userTable = await queryRunner.getTable("user_account");
+
+        // 1. 유니크 인덱스 삭제
+        if (userTable?.indices.find(index => index.name === "IDX_3be8d6d99d1cfeb79ef24b7710")) {
+            await queryRunner.dropIndex('user_account', "IDX_3be8d6d99d1cfeb79ef24b7710");
+        }
+
+        // 2. 일반 인덱스 삭제
+        if (userTable?.indices.find(index => index.name === "idx_login_id")) {
+            await queryRunner.dropIndex('user_account', "idx_login_id");
+        }
+    }
+}

--- a/src/migrations/1730903261891-AddCreatedAtIndices.ts
+++ b/src/migrations/1730903261891-AddCreatedAtIndices.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner, TableIndex, Table } from "typeorm";
+
+export class AddCreatedAtIndices1730903261891 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const postTable = await queryRunner.getTable("post");
+        const notificationTable = await queryRunner.getTable("notification");
+
+        // 1. post 테이블의 created_at 필드에 대한 인덱스 추가
+        const existingPostIndex = postTable?.indices.find(
+            index => index.name === "IDX_0f8f2f0c0512fbecbe3034b804"
+        );
+
+        // 인덱스가 이미 존재하지 않는 경우에만 생성
+        if (!existingPostIndex) {
+            await queryRunner.createIndex('post', new TableIndex({
+                name: "IDX_0f8f2f0c0512fbecbe3034b804",
+                columnNames: ['created_at']
+            }));
+        }
+
+        // 2. notification 테이블의 created_at 필드에 대한 인덱스 추가
+        const existingNotificationIndex = notificationTable?.indices.find(
+            index => index.name === "IDX_8bdc07e9c41ce8d83730f0f5d8"
+        );
+
+        // 인덱스가 이미 존재하지 않는 경우에만 생성
+        if (!existingNotificationIndex) {
+            await queryRunner.createIndex('notification', new TableIndex({
+                name: "IDX_8bdc07e9c41ce8d83730f0f5d8",
+                columnNames: ['created_at']
+            }));
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const postTable = await queryRunner.getTable("post");
+        const notificationTable = await queryRunner.getTable("notification");
+
+        // 1. post 테이블의 created_at 인덱스 삭제 (존재할 경우에만 삭제)
+        if (postTable?.indices.find(index => index.name === "IDX_0f8f2f0c0512fbecbe3034b804")) {
+            await queryRunner.dropIndex('post', "IDX_0f8f2f0c0512fbecbe3034b804");
+        }
+
+        // 2. notification 테이블의 created_at 인덱스 삭제 (존재할 경우에만 삭제)
+        if (notificationTable?.indices.find(index => index.name === "IDX_8bdc07e9c41ce8d83730f0f5d8")) {
+            await queryRunner.dropIndex('notification', "IDX_8bdc07e9c41ce8d83730f0f5d8");
+        }
+    }
+}

--- a/src/migrations/1730903335984-AddCreatedAtIndices.ts
+++ b/src/migrations/1730903335984-AddCreatedAtIndices.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner, TableForeignKey } from "typeorm";
+
+export class RemoveCascadeFromNotificationPost1730903335984 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // 1. notification 테이블의 기존 postId 외래 키 삭제 (CASCADE가 있을 경우에만 제거)
+        const notificationTable = await queryRunner.getTable("notification");
+        if (notificationTable) {
+            const existingForeignKey = notificationTable.foreignKeys.find(fk => fk.columnNames.includes("postId"));
+            
+            // 기존 외래 키가 존재할 경우에만 삭제
+            if (existingForeignKey) {
+                await queryRunner.dropForeignKey("notification", existingForeignKey);
+            }
+        }
+
+        // 2. CASCADE 없이 새로운 외래 키 FK_notification_post 추가
+        await queryRunner.createForeignKey("notification", new TableForeignKey({
+            name: "FK_notification_post",
+            columnNames: ["postId"],
+            referencedColumnNames: ["post_id"],
+            referencedTableName: "post"
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // 1. 기존 CASCADE가 없는 외래 키 FK_notification_post 삭제
+        await queryRunner.dropForeignKey("notification", "FK_notification_post");
+
+        // 2. CASCADE 옵션을 포함한 외래 키 FK_notification_post 재추가
+        await queryRunner.createForeignKey("notification", new TableForeignKey({
+            name: "FK_notification_post",
+            columnNames: ["postId"],
+            referencedColumnNames: ["post_id"],
+            referencedTableName: "post",
+            onDelete: "CASCADE"
+        }));
+    }
+}

--- a/src/migrations/1730947743974-AddEntityIndices.ts
+++ b/src/migrations/1730947743974-AddEntityIndices.ts
@@ -1,0 +1,98 @@
+import { MigrationInterface, QueryRunner, TableIndex } from "typeorm";
+
+export class AddEntityIndices1730947743974 implements MigrationInterface {
+   public async up(queryRunner: QueryRunner): Promise<void> {
+       // Comment 엔티티의 복합 인덱스 (post_id, created_at) 추가
+       const commentTable = await queryRunner.getTable("comment");
+       const existingCommentIndex = commentTable?.indices.find(
+           index => index.name === "IDX_comment_post_created_at"
+       );
+       if (!existingCommentIndex) {
+           await queryRunner.createIndex('comment', new TableIndex({
+               name: "IDX_comment_post_created_at",
+               columnNames: ['post_id', 'created_at']
+           }));
+       }
+
+       // Post 엔티티의 복합 인덱스 (user_id, created_at) 추가
+       const postTable = await queryRunner.getTable("post");
+       const existingPostIndex = postTable?.indices.find(
+           index => index.name === "IDX_post_user_created_at"
+       );
+       if (!existingPostIndex) {
+           await queryRunner.createIndex('post', new TableIndex({
+               name: "IDX_post_user_created_at",
+               columnNames: ['user_id', 'created_at']
+           }));
+       }
+
+       // Notification 엔티티의 복합 인덱스 (user_id, created_at) 추가
+       const notificationTable = await queryRunner.getTable("notification");
+       const existingNotificationIndex = notificationTable?.indices.find(
+           index => index.name === "IDX_notification_user_created_at"
+       );
+       if (!existingNotificationIndex) {
+           await queryRunner.createIndex('notification', new TableIndex({
+               name: "IDX_notification_user_created_at",
+               columnNames: ['user_id', 'created_at']
+           }));
+       }
+
+       // UserAccount의 login_id 인덱스 추가
+       const userAccountTable = await queryRunner.getTable("user_account");
+       const existingLoginIndex = userAccountTable?.indices.find(
+           index => index.name === "IDX_user_login_id"
+       );
+       if (!existingLoginIndex) {
+           await queryRunner.createIndex('user_account', new TableIndex({
+               name: "IDX_user_login_id",
+               columnNames: ['login_id']
+           }));
+       }
+
+       // UserAccount의 login_id에 유니크 제약조건 추가
+       const existingUniqueConstraint = userAccountTable?.uniques.find(
+           unique => unique.name === "UQ_user_login_id"
+       );
+       if (!existingUniqueConstraint) {
+           await queryRunner.query(`
+               ALTER TABLE user_account
+               ADD CONSTRAINT UQ_user_login_id UNIQUE (login_id)
+           `);
+       }
+   }
+
+   public async down(queryRunner: QueryRunner): Promise<void> {
+       // Comment 엔티티의 복합 인덱스 (post_id, created_at) 삭제
+       const commentTable = await queryRunner.getTable("comment");
+       if (commentTable?.indices.find(index => index.name === "IDX_comment_post_created_at")) {
+           await queryRunner.dropIndex('comment', "IDX_comment_post_created_at");
+       }
+
+       // Post 엔티티의 복합 인덱스 (user_id, created_at) 삭제
+       const postTable = await queryRunner.getTable("post");
+       if (postTable?.indices.find(index => index.name === "IDX_post_user_created_at")) {
+           await queryRunner.dropIndex('post', "IDX_post_user_created_at");
+       }
+
+       // Notification 엔티티의 복합 인덱스 (user_id, created_at) 삭제
+       const notificationTable = await queryRunner.getTable("notification");
+       if (notificationTable?.indices.find(index => index.name === "IDX_notification_user_created_at")) {
+           await queryRunner.dropIndex('notification', "IDX_notification_user_created_at");
+       }
+
+       // UserAccount의 login_id 인덱스 삭제
+       const userAccountTable = await queryRunner.getTable("user_account");
+       if (userAccountTable?.indices.find(index => index.name === "IDX_user_login_id")) {
+           await queryRunner.dropIndex('user_account', "IDX_user_login_id");
+       }
+
+       // UserAccount의 login_id 유니크 제약조건 삭제
+       if (userAccountTable?.uniques.find(unique => unique.name === "UQ_user_login_id")) {
+           await queryRunner.query(`
+               ALTER TABLE user_account
+               DROP CONSTRAINT UQ_user_login_id
+           `);
+       }
+   }
+}

--- a/src/migrations/1730972243552-RemoveCreatedAtIndices.ts
+++ b/src/migrations/1730972243552-RemoveCreatedAtIndices.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner, TableIndex } from "typeorm";
+
+export class RemoveCreatedAtIndices1730972243552 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const postTable = await queryRunner.getTable("post");
+        const notificationTable = await queryRunner.getTable("notification");
+
+        // post 테이블에서 created_at 인덱스 삭제
+        if (postTable?.indices.find(index => index.name === "IDX_0f8f2f0c0512fbecbe3034b804")) {
+            await queryRunner.dropIndex('post', "IDX_0f8f2f0c0512fbecbe3034b804");
+        }
+
+        // notification 테이블에서 created_at 인덱스 삭
+        if (notificationTable?.indices.find(index => index.name === "IDX_8bdc07e9c41ce8d83730f0f5d8")) {
+            await queryRunner.dropIndex('notification', "IDX_8bdc07e9c41ce8d83730f0f5d8");
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // post 테이블에 created_at 인덱스 다시 추가
+        await queryRunner.createIndex('post', new TableIndex({
+            name: "IDX_0f8f2f0c0512fbecbe3034b804",
+            columnNames: ['created_at']
+        }));
+
+        // notification 테이블에 created_at 인덱스 다시 추가
+        await queryRunner.createIndex('notification', new TableIndex({
+            name: "IDX_8bdc07e9c41ce8d83730f0f5d8",
+            columnNames: ['created_at']
+        }));
+    }
+}

--- a/src/migrations/1730973278883-RestoreCompositeIndices.ts
+++ b/src/migrations/1730973278883-RestoreCompositeIndices.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner, TableIndex } from "typeorm";
+
+export class RestoreCompositeIndices1730972243553 implements MigrationInterface {
+   public async up(queryRunner: QueryRunner): Promise<void> {
+       // Comment 엔티티의 복합 인덱스 추가
+       const commentTable = await queryRunner.getTable("comment");
+       if (commentTable && !commentTable.indices.find(index => index.name === "IDX_comment_post_created_at")) {
+           await queryRunner.createIndex('comment', new TableIndex({
+               name: "IDX_comment_post_created_at",
+               columnNames: ['post_id', 'created_at']
+           }));
+       }
+
+       // Post 엔티티의 복합 인덱스 추가
+       const postTable = await queryRunner.getTable("post");
+       if (postTable && !postTable.indices.find(index => index.name === "IDX_post_user_created_at")) {
+           await queryRunner.createIndex('post', new TableIndex({
+               name: "IDX_post_user_created_at",
+               columnNames: ['user_id', 'created_at']
+           }));
+       }
+
+       // Notification 엔티티의 복합 인덱스 추가
+       const notificationTable = await queryRunner.getTable("notification");
+       if (notificationTable && !notificationTable.indices.find(index => index.name === "IDX_notification_user_created_at")) {
+           await queryRunner.createIndex('notification', new TableIndex({
+               name: "IDX_notification_user_created_at",
+               columnNames: ['user_id', 'created_at']
+           }));
+       }
+   }
+
+   public async down(queryRunner: QueryRunner): Promise<void> {
+       // 복합 인덱스 삭제
+       const commentTable = await queryRunner.getTable("comment");
+       if (commentTable && commentTable.indices.find(index => index.name === "IDX_comment_post_created_at")) {
+           await queryRunner.dropIndex('comment', "IDX_comment_post_created_at");
+       }
+
+       const postTable = await queryRunner.getTable("post");
+       if (postTable && postTable.indices.find(index => index.name === "IDX_post_user_created_at")) {
+           await queryRunner.dropIndex('post', "IDX_post_user_created_at");
+       }
+
+       const notificationTable = await queryRunner.getTable("notification");
+       if (notificationTable && notificationTable.indices.find(index => index.name === "IDX_notification_user_created_at")) {
+           await queryRunner.dropIndex('notification', "IDX_notification_user_created_at");
+       }
+   }
+}

--- a/src/migrations/1730973620802-AddUserLoginIdIndexAndUniqueConstraint.ts
+++ b/src/migrations/1730973620802-AddUserLoginIdIndexAndUniqueConstraint.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner, TableIndex } from "typeorm";
+
+export class AddUserLoginIdIndexAndUniqueConstraint1730973620802 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // UserAccount 테이블의 인덱스 확인 및 생성
+        const userTable = await queryRunner.getTable("user_account");
+
+        const existingIndex = userTable?.indices.find(
+            index => index.name === "IDX_user_login_id"
+        );
+
+        // login_id 컬럼에 대한 일반 인덱스가 존재하지 않는 경우 생성
+        if (!existingIndex) {
+            await queryRunner.createIndex('user_account', new TableIndex({
+                name: "IDX_user_login_id",
+                columnNames: ['login_id']
+            }));
+        }
+
+        // UserAccount 테이블의 유니크 제약 조건 확인 및 생성
+        const existingUniqueConstraint = userTable?.uniques.find(
+            unique => unique.name === "UQ_user_login_id"
+        );
+
+        // login_id 컬럼에 대한 유니크 제약 조건이 존재하지 않는 경우 생성
+        if (!existingUniqueConstraint) {
+            await queryRunner.query(`
+                ALTER TABLE user_account
+                ADD CONSTRAINT UQ_user_login_id UNIQUE (login_id)
+            `);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // UserAccount 테이블의 인덱스 및 유니크 제약 조건 삭제
+        const userTable = await queryRunner.getTable("user_account");
+
+        // login_id 컬럼에 대한 일반 인덱스가 존재하는 경우 삭제
+        if (userTable?.indices.find(index => index.name === "IDX_user_login_id")) {
+            await queryRunner.dropIndex('user_account', "IDX_user_login_id");
+        }
+
+        // login_id 컬럼에 대한 유니크 제약 조건이 존재하는 경우 삭제
+        if (userTable?.uniques.find(unique => unique.name === "UQ_user_login_id")) {
+            await queryRunner.query(`
+                ALTER TABLE user_account
+                DROP CONSTRAINT UQ_user_login_id
+            `);
+        }
+    }
+}

--- a/src/migrations/1731032997204-AddNotNullConstraintsComplete.ts
+++ b/src/migrations/1731032997204-AddNotNullConstraintsComplete.ts
@@ -1,0 +1,188 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNotNullConstraintsComplete1699420000000 implements MigrationInterface {
+    
+    // 테이블과 해당 테이블의 체크할 컬럼들을 정의
+    private readonly tableColumns = {
+        'post': ['user_id'],
+        'comment': ['post_id', 'user_id'],
+        'post_like': ['post_id', 'user_id'],
+        'comment_like': ['comment_id', 'user_id'],
+        'business_contact': ['user_id', 'contact_user_id'],
+        'business_profile': ['user_id'],
+        'notification': ['user_id'],
+        'friend_request': ['sender_id', 'receiver_id']
+    };
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        try {
+            // 모든 테이블과 컬럼 존재 여부 확인
+            console.log('Checking tables and columns existence...');
+            await this.validateTablesAndColumns(queryRunner);
+
+            // NOT NULL 제약조건 추가
+            console.log('Adding NOT NULL constraints...');
+
+            // Post 테이블 수정
+            console.log('Modifying post table...');
+            await queryRunner.query(`
+                ALTER TABLE post
+                MODIFY COLUMN user_id INT NOT NULL;
+            `);
+
+            // Comment 테이블 수정
+            console.log('Modifying comment table...');
+            await queryRunner.query(`
+                ALTER TABLE comment
+                MODIFY COLUMN post_id INT NOT NULL,
+                MODIFY COLUMN user_id INT NOT NULL;
+            `);
+
+            // PostLike 테이블 수정
+            console.log('Modifying post_like table...');
+            await queryRunner.query(`
+                ALTER TABLE post_like
+                MODIFY COLUMN post_id INT NOT NULL,
+                MODIFY COLUMN user_id INT NOT NULL;
+            `);
+
+            // CommentLike 테이블 수정
+            console.log('Modifying comment_like table...');
+            await queryRunner.query(`
+                ALTER TABLE comment_like
+                MODIFY COLUMN comment_id INT NOT NULL,
+                MODIFY COLUMN user_id INT NOT NULL;
+            `);
+
+            // BusinessContact 테이블 수정
+            console.log('Modifying business_contact table...');
+            await queryRunner.query(`
+                ALTER TABLE business_contact
+                MODIFY COLUMN user_id INT NOT NULL,
+                MODIFY COLUMN contact_user_id INT NOT NULL;
+            `);
+
+            // BusinessProfile 테이블 수정
+            console.log('Modifying business_profile table...');
+            await queryRunner.query(`
+                ALTER TABLE business_profile
+                MODIFY COLUMN user_id INT NOT NULL;
+            `);
+
+            // Notification 테이블 수정
+            console.log('Modifying notification table...');
+            await queryRunner.query(`
+                ALTER TABLE notification
+                MODIFY COLUMN user_id INT NOT NULL;
+            `);
+
+            // FriendRequest 테이블 수정
+            console.log('Modifying friend_request table...');
+            await queryRunner.query(`
+                ALTER TABLE friend_request
+                MODIFY COLUMN sender_id INT NOT NULL,
+                MODIFY COLUMN receiver_id INT NOT NULL;
+            `);
+
+            console.log('Migration completed successfully!');
+
+        } catch (error) {
+            console.error('Migration failed:', error);
+            console.log('Starting rollback...');
+            await this.down(queryRunner);
+            throw error;
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        try {
+            // Post 테이블 롤백
+            console.log('Rolling back post table...');
+            await queryRunner.query(`
+                ALTER TABLE post
+                MODIFY COLUMN user_id INT NULL;
+            `);
+
+            // Comment 테이블 롤백
+            console.log('Rolling back comment table...');
+            await queryRunner.query(`
+                ALTER TABLE comment
+                MODIFY COLUMN post_id INT NULL,
+                MODIFY COLUMN user_id INT NULL;
+            `);
+
+            // PostLike 테이블 롤백
+            console.log('Rolling back post_like table...');
+            await queryRunner.query(`
+                ALTER TABLE post_like
+                MODIFY COLUMN post_id INT NULL,
+                MODIFY COLUMN user_id INT NULL;
+            `);
+
+            // CommentLike 테이블 롤백
+            console.log('Rolling back comment_like table...');
+            await queryRunner.query(`
+                ALTER TABLE comment_like
+                MODIFY COLUMN comment_id INT NULL,
+                MODIFY COLUMN user_id INT NULL;
+            `);
+
+            // BusinessContact 테이블 롤백
+            console.log('Rolling back business_contact table...');
+            await queryRunner.query(`
+                ALTER TABLE business_contact
+                MODIFY COLUMN user_id INT NULL,
+                MODIFY COLUMN contact_user_id INT NULL;
+            `);
+
+            // BusinessProfile 테이블 롤백
+            console.log('Rolling back business_profile table...');
+            await queryRunner.query(`
+                ALTER TABLE business_profile
+                MODIFY COLUMN user_id INT NULL;
+            `);
+
+            // Notification 테이블 롤백
+            console.log('Rolling back notification table...');
+            await queryRunner.query(`
+                ALTER TABLE notification
+                MODIFY COLUMN user_id INT NULL;
+            `);
+
+            // FriendRequest 테이블 롤백
+            console.log('Rolling back friend_request table...');
+            await queryRunner.query(`
+                ALTER TABLE friend_request
+                MODIFY COLUMN sender_id INT NULL,
+                MODIFY COLUMN receiver_id INT NULL;
+            `);
+
+            console.log('Rollback completed successfully!');
+
+        } catch (error) {
+            console.error('Rollback failed:', error);
+            throw error;
+        }
+    }
+
+    private async validateTablesAndColumns(queryRunner: QueryRunner): Promise<void> {
+        for (const [tableName, columns] of Object.entries(this.tableColumns)) {
+            // 테이블 존재 여부 확인
+            const tableExists = await queryRunner.hasTable(tableName);
+            if (!tableExists) {
+                throw new Error(`Table '${tableName}' does not exist`);
+            }
+
+            // 컬럼 존재 여부 확인
+            const table = await queryRunner.getTable(tableName);
+            for (const columnName of columns) {
+                const column = table.columns.find(col => col.name === columnName);
+                if (!column) {
+                    throw new Error(`Column '${columnName}' does not exist in table '${tableName}'`);
+                }
+            }
+            
+            console.log(`Validated table '${tableName}' and its columns`);
+        }
+    }
+}

--- a/src/migrations/1731038746433-AddForeignKeyConstraints.ts
+++ b/src/migrations/1731038746433-AddForeignKeyConstraints.ts
@@ -1,0 +1,186 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddForeignKeyConstraints1731038746433 implements MigrationInterface {
+    // 모든 테이블과 их의 외래 키 정의
+    private readonly tableConstraints = {
+        business_profile: [
+            {
+                name: 'FK_business_profile_user',
+                column: 'user_id',
+                referencedTable: 'user_account',
+                referencedColumn: 'user_id'
+            }
+        ],
+        business_contact: [
+            {
+                name: 'FK_business_contact_user',
+                column: 'user_id',
+                referencedTable: 'user_account',
+                referencedColumn: 'user_id'
+            },
+            {
+                name: 'FK_business_contact_contact_user',
+                column: 'contact_user_id',
+                referencedTable: 'user_account',
+                referencedColumn: 'user_id'
+            }
+        ],
+        post: [
+            {
+                name: 'FK_post_user',
+                column: 'user_id',
+                referencedTable: 'user_account',
+                referencedColumn: 'user_id'
+            }
+        ],
+        comment: [
+            {
+                name: 'FK_comment_user',
+                column: 'user_id',
+                referencedTable: 'user_account',
+                referencedColumn: 'user_id'
+            },
+            {
+                name: 'FK_comment_post',
+                column: 'post_id',
+                referencedTable: 'post',
+                referencedColumn: 'post_id'
+            }
+        ],
+        post_like: [
+            {
+                name: 'FK_post_like_user',
+                column: 'user_id',
+                referencedTable: 'user_account',
+                referencedColumn: 'user_id'
+            },
+            {
+                name: 'FK_post_like_post',
+                column: 'post_id',
+                referencedTable: 'post',
+                referencedColumn: 'post_id'
+            }
+        ],
+        comment_like: [
+            {
+                name: 'FK_comment_like_user',
+                column: 'user_id',
+                referencedTable: 'user_account',
+                referencedColumn: 'user_id'
+            },
+            {
+                name: 'FK_comment_like_comment',
+                column: 'comment_id',
+                referencedTable: 'comment',
+                referencedColumn: 'comment_id'
+            }
+        ],
+        friend_request: [
+            {
+                name: 'FK_friend_request_sender',
+                column: 'sender_id',
+                referencedTable: 'user_account',
+                referencedColumn: 'user_id'
+            },
+            {
+                name: 'FK_friend_request_receiver',
+                column: 'receiver_id',
+                referencedTable: 'user_account',
+                referencedColumn: 'user_id'
+            }
+        ],
+        notification: [
+            {
+                name: 'FK_notification_user',
+                column: 'user_id',
+                referencedTable: 'user_account',
+                referencedColumn: 'user_id'
+            }
+        ]
+    };
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        try {
+
+            // 모든 테이블 존재 여부 확인
+            for (const tableName of Object.keys(this.tableConstraints)) {
+                const exists = await queryRunner.hasTable(tableName);
+                if (!exists) {
+                    throw new Error(`Table ${tableName} does not exist. Migration cannot proceed.`);
+                }
+            }
+
+            // 각 테이블별로 외래 키 추가
+            for (const [tableName, constraints] of Object.entries(this.tableConstraints)) {
+                const table = await queryRunner.getTable(tableName);
+                const existingForeignKeys = table.foreignKeys.map(fk => fk.name);
+
+                // 각 제약조건 처리
+                for (const constraint of constraints) {
+                    if (!existingForeignKeys.includes(constraint.name)) {
+                        // 참조되는 컬럼이 NOT NULL인지 확인
+                        const columnInfo = await queryRunner.query(`
+                            SELECT IS_NULLABLE 
+                            FROM information_schema.COLUMNS 
+                            WHERE TABLE_SCHEMA = DATABASE()
+                            AND TABLE_NAME = '${tableName}' 
+                            AND COLUMN_NAME = '${constraint.column}'
+                        `);
+
+                        // NOT NULL이 아닌 경우 경고
+                        if (columnInfo[0]?.IS_NULLABLE === 'YES') {
+                            console.warn(`Warning: Column ${tableName}.${constraint.column} is nullable. Consider adding NOT NULL constraint.`);
+                        }
+
+                        // 외래 키 추가
+                        await queryRunner.query(`
+                            ALTER TABLE ${tableName}
+                            ADD CONSTRAINT ${constraint.name}
+                            FOREIGN KEY (${constraint.column})
+                            REFERENCES ${constraint.referencedTable}(${constraint.referencedColumn})
+                        `);
+
+                        console.log(`Added foreign key ${constraint.name} to ${tableName}.${constraint.column}`);
+                    } else {
+                        console.log(`Foreign key ${constraint.name} already exists on ${tableName}.${constraint.column}`);
+                    }
+                }
+            }
+
+            console.log('Foreign key constraints added successfully!');
+
+        } catch (error) {
+            console.error('Migration failed:', error);
+            throw error;
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        try {
+            // 이 마이그레이션에서 추가된 외래 키만 제거
+            for (const [tableName, constraints] of Object.entries(this.tableConstraints)) {
+                if (await queryRunner.hasTable(tableName)) {
+                    const table = await queryRunner.getTable(tableName);
+                    const existingForeignKeys = table.foreignKeys;
+
+                    for (const constraint of constraints) {
+                        const fk = existingForeignKeys.find(fk => fk.name === constraint.name);
+                        if (fk) {
+                            await queryRunner.query(`
+                                ALTER TABLE ${tableName}
+                                DROP FOREIGN KEY ${constraint.name}
+                            `);
+                            console.log(`Removed foreign key ${constraint.name} from ${tableName}`);
+                        }
+                    }
+                }
+            }
+
+            console.log('Foreign key constraints removed successfully!');
+
+        } catch (error) {
+            console.error('Rollback failed:', error);
+            throw error;
+        }
+    }
+}

--- a/src/migrations/1731039993812-AddNotificationForeignKeys.ts
+++ b/src/migrations/1731039993812-AddNotificationForeignKeys.ts
@@ -1,0 +1,87 @@
+import { MigrationInterface, QueryRunner, TableForeignKey } from "typeorm";
+
+export class AddNotificationForeignKeys1731039993812 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        try {
+            // notification 테이블 존재 여부 확인
+            const notificationExists = await queryRunner.hasTable("notification");
+            if (!notificationExists) {
+                throw new Error("notification table does not exist");
+            }
+
+            // post 테이블 존재 여부 확인
+            const postExists = await queryRunner.hasTable("post");
+            if (!postExists) {
+                throw new Error("post table does not exist");
+            }
+
+            // comment 테이블 존재 여부 확인
+            const commentExists = await queryRunner.hasTable("comment");
+            if (!commentExists) {
+                throw new Error("comment table does not exist");
+            }
+
+            // postId 컬럼에 대한 외래 키 추가
+            const postForeignKey = new TableForeignKey({
+                name: "FK_notification_post",
+                columnNames: ["postId"],
+                referencedColumnNames: ["post_id"],
+                referencedTableName: "post"
+            });
+
+            // commentId 컬럼에 대한 외래 키 추가
+            const commentForeignKey = new TableForeignKey({
+                name: "FK_notification_comment",
+                columnNames: ["commentId"],
+                referencedColumnNames: ["comment_id"],
+                referencedTableName: "comment"
+            });
+
+            // 기존 외래 키가 있는지 확인하고 없는 경우에만 추가
+            const table = await queryRunner.getTable("notification");
+            const existingPostFK = table.foreignKeys.find(fk => fk.columnNames.includes("postId"));
+            const existingCommentFK = table.foreignKeys.find(fk => fk.columnNames.includes("commentId"));
+
+            if (!existingPostFK) {
+                await queryRunner.createForeignKey("notification", postForeignKey);
+                console.log("Added foreign key for postId in notification table");
+            } else {
+                console.log("Foreign key for postId already exists");
+            }
+
+            if (!existingCommentFK) {
+                await queryRunner.createForeignKey("notification", commentForeignKey);
+                console.log("Added foreign key for commentId in notification table");
+            } else {
+                console.log("Foreign key for commentId already exists");
+            }
+
+        } catch (error) {
+            console.error("Migration failed:", error);
+            throw error;
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        try {
+            // 외래 키 제거
+            const table = await queryRunner.getTable("notification");
+            
+            const postFK = table.foreignKeys.find(fk => fk.columnNames.includes("postId"));
+            if (postFK) {
+                await queryRunner.dropForeignKey("notification", postFK);
+                console.log("Removed foreign key for postId");
+            }
+
+            const commentFK = table.foreignKeys.find(fk => fk.columnNames.includes("commentId"));
+            if (commentFK) {
+                await queryRunner.dropForeignKey("notification", commentFK);
+                console.log("Removed foreign key for commentId");
+            }
+
+        } catch (error) {
+            console.error("Rollback failed:", error);
+            throw error;
+        }
+    }
+}

--- a/src/migrations/1731044092418-AddLikesUniqueConstraints.ts
+++ b/src/migrations/1731044092418-AddLikesUniqueConstraints.ts
@@ -1,0 +1,96 @@
+import { MigrationInterface, QueryRunner, TableIndex } from "typeorm";
+
+export class AddLikesUniqueConstraints1731044092418 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        try {
+            // 중복 데이터 처리
+            console.log('Cleaning up duplicate post likes...');
+            await queryRunner.query(`
+                DELETE p1 FROM post_like p1
+                INNER JOIN post_like p2
+                WHERE 
+                    p1.post_id = p2.post_id
+                    AND p1.user_id = p2.user_id
+                    AND p1.post_like_id < p2.post_like_id
+            `);
+
+            console.log('Cleaning up duplicate comment likes...');
+            await queryRunner.query(`
+                DELETE c1 FROM comment_like c1
+                INNER JOIN comment_like c2
+                WHERE 
+                    c1.comment_id = c2.comment_id
+                    AND c1.user_id = c2.user_id
+                    AND c1.comment_like_id < c2.comment_like_id
+            `);
+
+            // post_like 테이블의 유니크 인덱스 추가
+            const postLikeTable = await queryRunner.getTable("post_like");
+            const existingPostLikeIndex = postLikeTable.indices.find(
+                index => index.name === "IDX_155b6bea641466e2d27ade96a4"
+            );
+
+            if (!existingPostLikeIndex) {
+                await queryRunner.createIndex('post_like', new TableIndex({
+                    name: "IDX_155b6bea641466e2d27ade96a4",
+                    columnNames: ['post_id', 'user_id'],
+                    isUnique: true
+                }));
+                console.log("Added unique index to post_like table");
+            }
+
+            // comment_like 테이블의 유니크 인덱스 추가
+            const commentLikeTable = await queryRunner.getTable("comment_like");
+            const existingCommentLikeIndex = commentLikeTable.indices.find(
+                index => index.name === "IDX_b81e662a725f9440050ac6e4e2"
+            );
+
+            if (!existingCommentLikeIndex) {
+                await queryRunner.createIndex('comment_like', new TableIndex({
+                    name: "IDX_b81e662a725f9440050ac6e4e2",
+                    columnNames: ['comment_id', 'user_id'],
+                    isUnique: true
+                }));
+                console.log("Added unique index to comment_like table");
+            }
+
+            console.log('Migration completed successfully!');
+
+        } catch (error) {
+            console.error("Migration failed:", error);
+            throw error;
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        try {
+            // post_like 테이블의 유니크 인덱스 제거
+            const postLikeTable = await queryRunner.getTable("post_like");
+            const postLikeIndex = postLikeTable.indices.find(
+                index => index.name === "IDX_155b6bea641466e2d27ade96a4"
+            );
+            
+            if (postLikeIndex) {
+                await queryRunner.dropIndex("post_like", postLikeIndex);
+                console.log("Removed unique index from post_like table");
+            }
+
+            // comment_like 테이블의 유니크 인덱스 제거
+            const commentLikeTable = await queryRunner.getTable("comment_like");
+            const commentLikeIndex = commentLikeTable.indices.find(
+                index => index.name === "IDX_b81e662a725f9440050ac6e4e2"
+            );
+            
+            if (commentLikeIndex) {
+                await queryRunner.dropIndex("comment_like", commentLikeIndex);
+                console.log("Removed unique index from comment_like table");
+            }
+
+            console.log('Rollback completed successfully!');
+
+        } catch (error) {
+            console.error("Rollback failed:", error);
+            throw error;
+        }
+    }
+}


### PR DESCRIPTION
엔티티 타입 더 명확하게 하고 기존 수동 마이그레이션으로 작업하여 인덱스, 유니크 제약 조건 제거
실질적으로 제가 생각했던 방향과 달랐던 마이그레이션 부분 수정
- 각 테이블마다 외래키로 연결하였는데, 사라져서 다시 외래키 추가
- 그 외래키로 관련된 컬럼 값들 전체 NOT NULL 추가(게시물이 생겼는데 그 작성자가 무조건 있어야 하기때문)
- 로그인 인덱스 추가, 및 기존에 포스트 생성날짜, 댓글 생성날짜 개인 인덱스 제거
- 게시물, 알람, 댓글 엔티티에 각 유저+ 생성날짜, 게시물 생성날짜 복합 인덱스 추가
- 댓글 좋아요, 게시물 좋아요 각 게시물or댓글 id + 유저id 묶어서 복합 유니크 인덱스 추가(각 사람마다 좋아요는 한개씩만 가능하게끔)
- 기존에 연쇄삭제 CASCADE 삭제
- 등 미흡했던 마이그레이션과 엔티티 코드 수정